### PR TITLE
Batched spend transactions support

### DIFF
--- a/messages.md
+++ b/messages.md
@@ -20,7 +20,7 @@ each watchtower. A watchtower needs to be able to sign any revocation transactio
 its corresponding wallet signs the unvaulting transaction.
 
 In addition, a watchtower will by default revault any unvaulting attempt. We need a way
-for an authorized spender to signal its willingness to spend a vault, and for the
+for a manager to signal its willingness to spend a vault, and for the
 watchtower to ACK or NACK it (cheaper and less onchain footprint than try-and-be-canceled).  
 For this matter we use the synchronisation server.
 
@@ -160,7 +160,7 @@ The `vault_uid` is `sha256(vault txid)`.
 
 #### `request_spend`
 
-Sent by an authorized spender to signal their willingness to spend a vault.
+Sent by a manager to signal their willingness to spend a vault.
 
 We use a timestamp as watchtowers might accept the same spending attempt in the future.
 
@@ -180,7 +180,7 @@ The `vault_uid` is `sha256(vault txid)`.
 
 #### `get_spend_opinions`
 
-Sent by an authorized spender when polling for watchtowers agreement regarding the spend
+Sent by a manager when polling for watchtowers agreement regarding the spend
 attempt identified by `vault_id`.
 
 ```json

--- a/messages.md
+++ b/messages.md
@@ -7,9 +7,9 @@ This messages are exchanged on top of an encrypted and authenticated communicati
 channel.
 
 
-- [Watchtower](watchtower)
-- [Cosigning server](cosigning-server)
-- [Synchronisation server](sync-server)
+- [Watchtower](#watchtower)
+- [Cosigning server](#cosigning-server)
+- [Synchronisation server](#sync-server)
 
 
 

--- a/transactions.md
+++ b/transactions.md
@@ -2,7 +2,7 @@
 
 All transactions are version 2 and use version 0 native Segwit scripts.
 
-We denote `N` the number of participants, `M` the number of authorized spenders (the subset
+We denote `N` the number of participants, `M` the number of managers (the subset
 of the participants allowed to unlock the unvault transaction output along with the
 cosigning servers), and `X` the CSV value in the unvault transaction.
 
@@ -44,10 +44,10 @@ With `<vault_script>` being:
 ## unvault_tx
 
 The transaction which spends the [`vault_tx`](vault_tx) deposit output, and creates an
-unvault output only spendable by the authorized spenders (along with the cosigning servers)
+unvault output only spendable by the managers (along with the cosigning servers)
 after `X` blocks.
 
-Note that the `M` pubkeys of the authorized spenders are used first in the output script
+Note that the `M` pubkeys of the managers are used first in the output script
 for opimisation purpose (they are needed in both spending path anyway).
 
 FIXME(darosior): try miniscript again.
@@ -85,7 +85,7 @@ FIXME(darosior): try miniscript again.
             # The everyone's-signing path, used for pre-signed transactions
             <pubkey M+1> CHECKSIGVERIFY ... <pubkey N> CHECKSIG
         ELSE
-            # The authorized spenders + cosigning servers path, used by the spend transaction
+            # The managers + cosigning servers path, used by the spend transaction
             X CHECKSEQUENCEVERIFY DROP
             <cosigner M+1> CHECKSIGVERIFY ... <cosigner N> CHECKSIG
         ENDIF


### PR DESCRIPTION
This:
- Renames the `atuhorized spenders` to `managers`. Shesek asked me while writing the [Minsc Revault policy example](https://bitcointalk.org/index.php?topic=5265745.msg54903902#msg54903902) if the managers were a different entity. I think it's also preferable to consistently choose `managers` instead of `authorized spenders`, as the "authorized` adjective may be confused as related to the local scope of the sentence ("in this specific case the spender is authorized") while "managers" reflects imho more the global role of the day-to-day funds managers: they can spend at anytime.
- Makes tiny changes to the "protocol" to correctly handle batched spending attempts (the most notable one is the cosigner's `sign` where i previously assumed there was only one input to the tx).