### PR TITLE
messages: use the outpoint in the `sig` message

### DIFF
--- a/messages.md
+++ b/messages.md
@@ -74,7 +74,7 @@ participants.
             ...
         },
         "txid": "txid",
-        "vault_txid": "vault transaction txid"
+        "deposit_outpoint": "deposit utxo outpoint"
     }
 }
 ```
@@ -339,7 +339,6 @@ No explicit ACK from the server as the wallet can just `get_sigs` for its own si
 #### `get_sigs`
 
 Sent by a wallet to retrieve all signatures for a specific transaction.
-FIXME: managers' wallets can currently get all signatures !!
 
 ```json
 {
@@ -561,7 +560,7 @@ it can, but only once.
     ||   <-- sign result ----    ||   // Server: *signs* .. Here you go.
     ||
     ||   -B-- sign  -------->    ||   // B: I need you to sign this same transaction input
-    ||   <-- sign result ----    ||   // Server: I already signed an input spending this txid, here is the existing signature
+    ||   <-- sign result ----    ||   // Server: I already signed an input spending this outpoint, here is the existing signature
 ```
 
 ### Messages format

--- a/transactions.md
+++ b/transactions.md
@@ -50,7 +50,7 @@ servers) after `X` blocks.
 - count: 1
 - inputs[0]:
     - txid: `<deposit_tx txid>`
-    - vout: N/A
+    - vout: `<deposit_tx vout>`
     - sequence: `0xfffffffd`
     - scriptSig: `<empty>`
     - witness: `satisfy(vault_descriptor)`
@@ -151,7 +151,7 @@ The transaction which spends the [`vault_tx`](vault_tx) output to the EDV by the
 - count: 1
 - inputs[0]:
     - txid: `<deposit_tx txid>`
-    - vout: N/A
+    - vout: `<deposit_tx vout>`
     - sequence: `0xfffffffd`
     - scriptSig: `<empty>`
     - witness: `satisfy(vault_descriptor)`


### PR DESCRIPTION
Quite a big overlook on this one..

I also grepped for `txid` and fixed a few inconsistencies.

Fixes https://github.com/re-vault/practical-revault/issues/62

Signed-off-by: Antoine Poinsot <darosior@protonmail.com>