### PR TITLE
messages: remove Emergency signature encryption

### DIFF
--- a/transactions.md
+++ b/transactions.md
@@ -143,6 +143,8 @@ funds. They lock coins to what we call an EDV (Emergency Deep Vault): a script c
 by the participants and kept obfuscated by the properties of P2WSH, as the emergency 
 transactions are never meant to be used.
 
+The Emergency `scriptPubKey` is not known to the managers.
+
 
 ### vault_emergency_tx
 


### PR DESCRIPTION
Instead of using boutique encryption of the signatures, we make the
Emergency `scriptPubKey` a private data. This achieves the same goal
without the pitfalls of a hacky encryption usage.

See https://github.com/re-vault/practical-revault/issues/72 for more
details.

Fixes #72

Signed-off-by: Antoine Poinsot <darosior@protonmail.com>